### PR TITLE
Add NetlinkEvent type

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -10,6 +10,15 @@ use crate::{
     NetlinkSerializable, Parseable,
 };
 
+/// Represent a Netlink event
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum NetlinkEvent<M> {
+    /// An actual message was received from Netlink
+    Message(M),
+    /// The socket receive buffer filled up
+    Overrun,
+}
+
 /// Represent a netlink message.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct NetlinkMessage<I> {


### PR DESCRIPTION
A Netlink event is an unsolicited event from netlink. In most cases, it will be a Netlink message, but it may also be an overrun notification.

This is a direct port of https://github.com/little-dude/netlink/pull/293.