### PR TITLE
Mark all public struct/enum as non_exhaustive

### DIFF
--- a/examples/protocol.rs
+++ b/examples/protocol.rs
@@ -126,5 +126,5 @@ fn main() {
     // NetlinkMessage { header: NetlinkHeader { length: 20, message_type: 18,
     // flags: 0, sequence_number: 0, port_number: 0 }, payload:
     // InnerMessage(Ping([0, 1, 2, 3])) }
-    println!("{:?}", packet);
+    println!("{packet:?}");
 }

--- a/examples/rtnetlink.rs
+++ b/examples/rtnetlink.rs
@@ -37,5 +37,5 @@ fn main() {
     // than the serialized one.
     assert_eq!(deserialized_packet, packet);
 
-    println!("{:?}", packet);
+    println!("{packet:?}");
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -103,6 +103,7 @@ pub const NETLINK_HEADER_LEN: usize = PAYLOAD.start;
 /// Note that in this second example we don't call
 /// [`new_checked()`](struct.NetlinkBuffer.html#method.new_checked) because the length field is
 /// initialized to 0, so `new_checked()` would return an error.
+#[non_exhaustive]
 pub struct NetlinkBuffer<T> {
     pub buffer: T,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,8 +36,8 @@ impl<T: AsRef<[u8]>> ErrorBuffer<T> {
         let len = self.buffer.as_ref().len();
         if len < ERROR_HEADER_LEN {
             Err(format!(
-                "invalid ErrorBuffer: length is {} but ErrorBuffer are at least {} bytes",
-                len, ERROR_HEADER_LEN
+                "invalid ErrorBuffer: length is {len} but ErrorBuffer are \
+                at least {ERROR_HEADER_LEN} bytes"
             )
             .into())
         } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ const PAYLOAD: Rest = 4..;
 const ERROR_HEADER_LEN: usize = PAYLOAD.start;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub struct ErrorBuffer<T> {
     buffer: T,
 }
@@ -77,6 +78,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> ErrorBuffer<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ErrorMessage {
     pub code: i32,
     pub header: Vec<u8>,

--- a/src/header.rs
+++ b/src/header.rs
@@ -20,6 +20,7 @@ use crate::{buffer::NETLINK_HEADER_LEN, Emitable, NetlinkBuffer, Parseable};
 /// +----------------+----------------+----------------+----------------+
 /// ```
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Default)]
+#[non_exhaustive]
 pub struct NetlinkHeader {
     /// Length of the netlink packet, including the header and the payload
     pub length: u32,

--- a/src/message.rs
+++ b/src/message.rs
@@ -14,6 +14,7 @@ use crate::{
 
 /// Represent a netlink message.
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub struct NetlinkMessage<I> {
     /// Message header (this is common to all the netlink protocols)
     pub header: NetlinkHeader,

--- a/src/message.rs
+++ b/src/message.rs
@@ -111,11 +111,9 @@ where
             NLMSG_DONE => Done,
             NLMSG_OVERRUN => Overrun(bytes.to_vec()),
             message_type => {
-                let inner_msg =
-                    I::deserialize(&header, bytes).context(format!(
-                        "Failed to parse message with type {}",
-                        message_type
-                    ))?;
+                let inner_msg = I::deserialize(&header, bytes).context(
+                    format!("Failed to parse message with type {message_type}"),
+                )?;
                 InnerMessage(inner_msg)
             }
         };

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -16,6 +16,7 @@ pub const NLMSG_OVERRUN: u16 = 4;
 pub const NLMSG_ALIGNTO: u16 = 4;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum NetlinkPayload<I> {
     Done,
     Error(ErrorMessage),


### PR DESCRIPTION
All the public struct/enum in nmstate might add members/type, hence marking
them as non_exhaustive which will prevent API user from in-compatibility
usage.

This allows us to only preserve API compatibility when adding new member to
struct or enum.

Please refer to
https://doc.rust-lang.org/reference/attributes/type_system.html for more
detail.