### PR TITLE
New release 0.5.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,15 @@
+# Changelog
+## [0.5.0] - 2023-01-28
+### Breaking changes
+ - All public struct and enum are marked as `non_exhaustive`. Please check
+   https://doc.rust-lang.org/reference/attributes/type_system.html for more
+   detail. (53a4c4e)
+
+ - Removed the reexport `netlink-packet-core::utils`, please use
+   `netlink_packet_utils` directly. (a76010a)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-core"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2018"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-core"
@@ -15,7 +15,7 @@ description = "netlink packet types"
 anyhow = "1.0.31"
 byteorder = "1.3.2"
 libc = "0.2.66"
-netlink-packet-utils = "0.5.1"
+netlink-packet-utils = "0.5.2"
 
 [dev-dependencies]
 netlink-packet-route = "0.13.0"


### PR DESCRIPTION
=== Breaking changes
 - All public struct and enum are marked as `non_exhaustive`. Please check
   https://doc.rust-lang.org/reference/attributes/type_system.html for more
   detail. (53a4c4e)

 - Removed the reexport `netlink-packet-core::utils`, please use
   `netlink_packet_utils` directly. (a76010a)

=== New features
 - N/A

=== Bug fixes
 - N/A