### PR TITLE
New release 0.6.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,15 @@
 # Changelog
+## [0.6.0] - 2023-06-26
+### Breaking changes
+ - `NetlinkPayload::Done` changed to `NetlinkPayload::Done(DoneMessage)`.
+   (0c75fb5)
+
+### New features
+ - Support full done message. (0c75fb5)
+
+### Bug fixes
+ - N/A
+
 ## [0.5.0] - 2023-01-28
 ### Breaking changes
  - All public struct and enum are marked as `non_exhaustive`. Please check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2018"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-core"
@@ -14,7 +14,6 @@ description = "netlink packet types"
 [dependencies]
 anyhow = "1.0.31"
 byteorder = "1.3.2"
-libc = "0.2.66"
 netlink-packet-utils = "0.5.2"
 
 [dev-dependencies]


### PR DESCRIPTION
=== Breaking changes
 - `NetlinkPayload::Done` changed to `NetlinkPayload::Done(DoneMessage)`.
   (0c75fb5)

=== New features
 - Support full done message. (0c75fb5)

=== Bug fixes
 - N/A