### PR TITLE
New release 0.7.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,15 @@
 # Changelog
+## [0.7.0] - 2023-07-09
+### Breaking changes
+ - `NetlinkPayload::Ack` removed and replaced by `NetlinkPayload::Error` where
+    `ErrorMessage.code` is set to None. (52732b3)
+
+### New features
+ - Derive `Default` for `ErrorMessage`. (3514766)
+
+### Bug fixes
+ - N/A
+
 ## [0.6.0] - 2023-06-26
 ### Breaking changes
  - `NetlinkPayload::Done` changed to `NetlinkPayload::Done(DoneMessage)`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2018"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-core"


### PR DESCRIPTION
=== Breaking changes
 - `NetlinkPayload::Ack` removed and replaced by `NetlinkPayload::Error` where
    `ErrorMessage.code` is set to None. (52732b3)

=== New features
 - Derive `Default` for `ErrorMessage`. (3514766)

=== Bug fixes
 - N/A