### PR TITLE
Switching to `thiserror` as the main method of handling errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ repository = "https://github.com/rust-netlink/netlink-packet-core"
 description = "netlink packet types"
 
 [dependencies]
-anyhow = "1.0.31"
 byteorder = "1.3.2"
-netlink-packet-utils = "0.5.2"
+netlink-packet-utils = { git = "https://github.com/miguelfrde/netlink-packet-utils.git" }
+thiserror = "2.0.9"
 
 [dev-dependencies]
 netlink-packet-route = "0.13.0"

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::DecodeError;
-
+use crate::CoreError;
 use crate::{buffer::NETLINK_HEADER_LEN, Emitable, NetlinkBuffer, Parseable};
 
 /// A Netlink header representation. A netlink header has the following
@@ -57,7 +56,9 @@ impl Emitable for NetlinkHeader {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NetlinkBuffer<&'a T>>
     for NetlinkHeader
 {
-    fn parse(buf: &NetlinkBuffer<&'a T>) -> Result<NetlinkHeader, DecodeError> {
+    type Error = CoreError;
+
+    fn parse(buf: &NetlinkBuffer<&'a T>) -> Result<NetlinkHeader, Self::Error> {
         Ok(NetlinkHeader {
             length: buf.length(),
             message_type: buf.message_type(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,3 +270,51 @@ pub use self::constants::*;
 
 pub(crate) use self::utils::traits::*;
 pub(crate) use netlink_packet_utils as utils;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CoreError {
+    #[error("invalid netlink buffer: length is {received} but netlink packets are at least {expected} bytes")]
+    PacketTooShort { received: usize, expected: usize },
+
+    #[error("invalid netlink buffer: length field says {expected} but the buffer is {actual} bytes long")]
+    NonmatchingLength { expected: u32, actual: usize },
+
+    #[error("invalid netlink buffer: length field says {given} but netlink packets are at least {at_least} bytes")]
+    InvalidLength { given: u32, at_least: usize },
+
+    #[error(
+        "invalid ErrorBuffer: length is {received}, expected at least 4 bytes"
+    )]
+    InvalidErrorBuffer { received: usize },
+
+    #[error(
+        "invalid DoneBuffer: length is {received}, expected at least 4 bytes"
+    )]
+    InvalidDoneBuffer { received: usize },
+
+    #[error("invalid Netlink header")]
+    InvalidHeader {
+        #[source]
+        due_to: Box<Self>,
+    },
+
+    #[error("invalid Netlink message of type NLMSG_ERROR")]
+    InvalidErrorMsg {
+        #[source]
+        due_to: Box<Self>,
+    },
+
+    #[error("invalid Netlink message of type NLMSG_DONE")]
+    InvalidDoneMsg {
+        #[source]
+        due_to: Box<Self>,
+    },
+
+    #[error("failed to parse the netlink message, of type {message_type}")]
+    ParseFailure {
+        message_type: u16,
+        #[source]
+        due_to: Box<dyn std::error::Error>,
+    },
+}


### PR DESCRIPTION
Done in sync with rust-netlink/netlink-packet-utils#13. This will have to be merged after the corresponding `netlink-packet-utils` PR.

Another thing worth considering is to merge `netlink-packet-utils` into `netlink-packet-core` so that we don't have to unnecessarily split the error enums into `DecodeError` and `CoreError`.