### PR TITLE
Revert "Mark all public struct/enum as non_exhaustive"

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -103,7 +103,6 @@ pub const NETLINK_HEADER_LEN: usize = PAYLOAD.start;
 /// Note that in this second example we don't call
 /// [`new_checked()`](struct.NetlinkBuffer.html#method.new_checked) because the length field is
 /// initialized to 0, so `new_checked()` would return an error.
-#[non_exhaustive]
 pub struct NetlinkBuffer<T> {
     pub buffer: T,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,6 @@ const PAYLOAD: Rest = 4..;
 const ERROR_HEADER_LEN: usize = PAYLOAD.start;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[non_exhaustive]
 pub struct ErrorBuffer<T> {
     buffer: T,
 }
@@ -88,7 +87,6 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> ErrorBuffer<T> {
 ///
 /// [RFC 3549 section 2.3.2.2]: https://datatracker.ietf.org/doc/html/rfc3549#section-2.3.2.2
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-#[non_exhaustive]
 pub struct ErrorMessage {
     /// The error code.
     ///

--- a/src/header.rs
+++ b/src/header.rs
@@ -20,7 +20,6 @@ use crate::{buffer::NETLINK_HEADER_LEN, Emitable, NetlinkBuffer, Parseable};
 /// +----------------+----------------+----------------+----------------+
 /// ```
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Default)]
-#[non_exhaustive]
 pub struct NetlinkHeader {
     /// Length of the netlink packet, including the header and the payload
     pub length: u32,

--- a/src/message.rs
+++ b/src/message.rs
@@ -14,7 +14,6 @@ use crate::{
 
 /// Represent a netlink message.
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[non_exhaustive]
 pub struct NetlinkMessage<I> {
     /// Message header (this is common to all the netlink protocols)
     pub header: NetlinkHeader,

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -16,7 +16,6 @@ pub const NLMSG_OVERRUN: u16 = 4;
 pub const NLMSG_ALIGNTO: u16 = 4;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[non_exhaustive]
 pub enum NetlinkPayload<I> {
     Done(DoneMessage),
     Error(ErrorMessage),


### PR DESCRIPTION
This reverts commit 53a4c4ecfec60e1f26ad8b6aaa62abc7b112df50.

While the idea of having forward compatibility was sound, the commit effectively disallowed *any* Netlink message to be created:

```rust
    let mut packet = NetlinkMessage {
        header: NetlinkHeader {
            sequence_number: 1,
            flags: NLM_F_DUMP | NLM_F_REQUEST,
            ..Default::default()
        },
        payload: RtnlMessage::GetLink(LinkMessage::default()).into(),
    };
```

```
error[E0639]: cannot create non-exhaustive struct using struct expression
```

This is just silly.