### PR TITLE
Bump netlink-packet-utils to v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "netlink packet types"
 [dependencies]
 anyhow = "1.0.31"
 byteorder = "1.3.2"
-netlink-packet-utils = "0.5.2"
+netlink-packet-utils = "0.6.0"
 
 [dev-dependencies]
 netlink-packet-route = "0.13.0"

--- a/src/done.rs
+++ b/src/done.rs
@@ -97,10 +97,12 @@ impl Emitable for DoneMessage {
     }
 }
 
-impl<'buffer, T: AsRef<[u8]> + 'buffer> Parseable<DoneBuffer<&'buffer T>>
+impl<T: AsRef<[u8]>> Parseable<DoneBuffer<&T>>
     for DoneMessage
 {
-    fn parse(buf: &DoneBuffer<&'buffer T>) -> Result<DoneMessage, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &DoneBuffer<&T>) -> Result<DoneMessage, Self::Error> {
         Ok(DoneMessage {
             code: buf.code(),
             extended_ack: buf.extended_ack().to_vec(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,12 +115,14 @@ impl Emitable for ErrorMessage {
     }
 }
 
-impl<'buffer, T: AsRef<[u8]> + 'buffer> Parseable<ErrorBuffer<&'buffer T>>
+impl<T: AsRef<[u8]>> Parseable<ErrorBuffer<&T>>
     for ErrorMessage
 {
+    type Error = DecodeError;
+
     fn parse(
-        buf: &ErrorBuffer<&'buffer T>,
-    ) -> Result<ErrorMessage, DecodeError> {
+        buf: &ErrorBuffer<&T>,
+    ) -> Result<ErrorMessage, Self::Error> {
         // FIXME: The payload of an error is basically a truncated packet, which
         // requires custom logic to parse correctly. For now we just
         // return it as a Vec<u8> let header: NetlinkHeader = {

--- a/src/header.rs
+++ b/src/header.rs
@@ -54,10 +54,12 @@ impl Emitable for NetlinkHeader {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NetlinkBuffer<&'a T>>
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NetlinkBuffer<&T>>
     for NetlinkHeader
 {
-    fn parse(buf: &NetlinkBuffer<&'a T>) -> Result<NetlinkHeader, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NetlinkBuffer<&T>) -> Result<NetlinkHeader, Self::Error> {
         Ok(NetlinkHeader {
             length: buf.length(),
             message_type: buf.message_type(),


### PR DESCRIPTION
Bump `netlink-packet-utils` version to v0.6.0. No functional change.

The motivation is to eventually get rid of older dependencies: duplicated versions of `thiserror` and unmaintained crate `paste` (see https://github.com/rust-netlink/netlink-packet-utils/issues/20#issue-2953044670 for more context).

The commit bumps the version for `netlink-packet-utils`, and adjusts error handling accordingly. Note that I'm not 100% sure I handled the errors correctly (at least it builds and tests still pass), so let me know if there are some more adjustments required.

Note: I thought of creating a version bump commit in the same PR, but I see this one needs to go first if we want the right commit SHA in the changelog.