### PR TITLE
Remove unused crate anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/rust-netlink/netlink-packet-core"
 description = "netlink packet types"
 
 [dependencies]
-anyhow = "1.0.31"
 byteorder = "1.3.2"
 netlink-packet-utils = "0.6.0"
 


### PR DESCRIPTION
Since commit 01e8dd1ff1e8 ("Bump netlink-packet-utils to v0.6.0"), crate anyhow is no longer used. Let's remove it.
