### PR TITLE
Support zero sized done message

### DIFF
--- a/src/done.rs
+++ b/src/done.rs
@@ -9,7 +9,7 @@ use crate::{
 
 const CODE: Field = 0..4;
 const EXTENDED_ACK: Rest = 4..;
-const DONE_HEADER_LEN: usize = EXTENDED_ACK.start;
+pub(crate) const DONE_HEADER_LEN: usize = EXTENDED_ACK.start;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]


### PR DESCRIPTION
In kernel `drivers/net/team/team_core.c`, the function
`team_nl_send_options_get()` is using zero sized done message:

```c
nlh = nlmsg_put(skb, portid, seq, NLMSG_DONE, 0, flags | NLM_F_MULTI);
```

This patch just generate [0u8;4] as buffer when got zero sized done
message received.