### PR TITLE
New release 0.8.0

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,5 @@
 max_width = 80
 wrap_comments = true
 reorder_imports = true
+format_strings = true
 edition = "2021"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,17 @@
 # Changelog
+## [0.8.0] - 2025-08-27
+### Breaking changes
+ - Changed `DecodeError` from enum to struct. (f55d7b7, 63da36a)
+ - Merged `netlink-packet-utils` into `netlink-packet-core`. (f55d7b7, 0951455,
+   ba127bf, a232478, 8027f63, 41fe03d, 260e596, cc6bf08, 63da36a, 410c61d)
+ - Remove dependency of byteorder crate. (16d63fb)
+
+### New features
+ - Support zero sized done message. (100413a)
+
+### Bug fixes
+ - N/A
+
 ## [0.7.0] - 2023-07-09
 ### Breaking changes
  - `NetlinkPayload::Ack` removed and replaced by `NetlinkPayload::Error` where

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-core"
 version = "0.7.0"
-edition = "2018"
+edition = "2021"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-core"
 keywords = ["netlink", "linux"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-core"

--- a/src/done.rs
+++ b/src/done.rs
@@ -39,8 +39,8 @@ impl<T: AsRef<[u8]>> DoneBuffer<T> {
         let len = self.buffer.as_ref().len();
         if len < DONE_HEADER_LEN {
             Err(format!(
-                "invalid DoneBuffer: length is {len} but DoneBuffer are \
-                at least {DONE_HEADER_LEN} bytes"
+                "invalid DoneBuffer: length is {len} but DoneBuffer are at \
+                 least {DONE_HEADER_LEN} bytes"
             )
             .into())
         } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,51 +75,71 @@ impl DecodeError {
     ) -> Self {
         Self {
             msg: format!(
-                "Invalid buffer {name}. \
-                Expected at least {minimum_length} bytes, \
-                received {received} bytes"
+                "Invalid buffer {name}. Expected at least {minimum_length} \
+                 bytes, received {received} bytes"
             ),
         }
     }
     pub fn invalid_mac_address(received: usize) -> Self {
-        Self{
-            msg: format!("Invalid MAC address. Expected 6 bytes, received {received} bytes"),
+        Self {
+            msg: format!(
+                "Invalid MAC address. Expected 6 bytes, received {received} \
+                 bytes"
+            ),
         }
     }
 
     pub fn invalid_ip_address(received: usize) -> Self {
-        Self{
-            msg: format!("Invalid IP address. Expected 4 or 16 bytes, received {received} bytes"),
+        Self {
+            msg: format!(
+                "Invalid IP address. Expected 4 or 16 bytes, received \
+                 {received} bytes"
+            ),
         }
     }
 
     pub fn invalid_number(expected: usize, received: usize) -> Self {
-        Self{
-            msg: format!("Invalid number. Expected {expected} bytes, received {received} bytes"),
+        Self {
+            msg: format!(
+                "Invalid number. Expected {expected} bytes, received \
+                 {received} bytes"
+            ),
         }
     }
 
     pub fn nla_buffer_too_small(buffer_len: usize, nla_len: usize) -> Self {
-        Self{
-            msg: format!("buffer has length {buffer_len}, but an NLA header is {nla_len} bytes"),
+        Self {
+            msg: format!(
+                "buffer has length {buffer_len}, but an NLA header is \
+                 {nla_len} bytes"
+            ),
         }
     }
 
     pub fn nla_length_mismatch(buffer_len: usize, nla_len: usize) -> Self {
-        Self{
-            msg: format!("buffer has length: {buffer_len}, but the NLA is {nla_len} bytes"),
+        Self {
+            msg: format!(
+                "buffer has length: {buffer_len}, but the NLA is {nla_len} \
+                 bytes"
+            ),
         }
     }
 
     pub fn nla_invalid_length(buffer_len: usize, nla_len: usize) -> Self {
-        Self{
-            msg: format!("NLA has invalid length: {nla_len} (should be at least {buffer_len} bytes)"),
+        Self {
+            msg: format!(
+                "NLA has invalid length: {nla_len} (should be at least \
+                 {buffer_len} bytes)"
+            ),
         }
     }
 
     pub fn buffer_too_small(buffer_len: usize, value_len: usize) -> Self {
         Self {
-            msg: format!("Buffer too small: {buffer_len} (should be at least {value_len} bytes"),
+            msg: format!(
+                "Buffer too small: {buffer_len} (should be at least \
+                 {value_len} bytes"
+            ),
         }
     }
 }
@@ -154,7 +174,7 @@ impl<T: AsRef<[u8]>> ErrorBuffer<T> {
             Err(DecodeError {
                 msg: format!(
                     "invalid ErrorBuffer: length is {len} but ErrorBuffer are \
-                at least {ERROR_HEADER_LEN} bytes"
+                     at least {ERROR_HEADER_LEN} bytes"
                 ),
             })
         } else {


### PR DESCRIPTION
=== Breaking changes
- Changed `DecodeError` from enum to struct. (f55d7b7, 63da36a)
- Merged `netlink-packet-utils` into `netlink-packet-core`. (f55d7b7,
  0951455, ba127bf, a232478, 8027f63, 41fe03d, 260e596, cc6bf08, 63da36a,
  410c61d)
- Remove dependency of byteorder crate. (16d63fb)

=== New features
- Support zero sized done message. (100413a)

=== Bug fixes
- N/A