### PR TITLE
Explicitly bind lifetimes for NlaBuffer.value()

### DIFF
--- a/src/nla.rs
+++ b/src/nla.rs
@@ -375,13 +375,35 @@ mod tests {
         assert_eq!(nla_align!(get_len() - 3), usize::MAX);
     }
 
-    // compile-time test, should not result in compiler complaints regarding
-    // lifetimes or returning values allegedly owned by this function
-    #[allow(dead_code)]
-    fn nla_buffer_outlives_value(nlas: &[u8]) -> Option<&[u8]> {
-        for nla in NlasIterator::new(nlas) {
-            return Some(nla.unwrap().value())
-        }
-        None
+    // compile-time test: it should be possible to pass &[u8] through
+    // NlasIterator and return one of its output &[u8]s without facing
+    // compiler error about lifetimes and returning borrows from something
+    // that this funciton owns
+    fn last_nla_from_buffer(nlas: &[u8]) -> Option<Result<&[u8], DecodeError>> {
+        NlasIterator::new(nlas).last()
+            .map(|nla| nla.map(|nla| nla.value()))
+    }
+
+    #[test]
+    fn test_nlas_iterator() {
+        // sample NFTA_LIST_ELEM from nftables, with nested nlas at the end
+        static NESTED_NLAS: &[u8] = &[
+            0x0c, 0x00, 0x01, 0x00,
+            0x63, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x00,
+            0x1c, 0x00, 0x02, 0x00,
+            0x0c, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x47, 0xda, 0x7a, 0x03,
+            0x1b, 0x0c, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x8e, 0x14,
+            0x56, 0x39
+        ];
+        let mut iter = NlasIterator::new(NESTED_NLAS);
+        // DecodeError does not implement PartialEq, hence
+        // unwrap() and is_none()
+        assert_eq!(iter.next().unwrap().unwrap().value(), &NESTED_NLAS[4..12]);
+        assert_eq!(iter.next().unwrap().unwrap().value(), &NESTED_NLAS[16..]);
+        assert!(iter.next().is_none());
+
+        // this sholud be an Err()
+        let truncated = &NESTED_NLAS[ .. NESTED_NLAS.len()-1];
+        assert!(last_nla_from_buffer(truncated).unwrap().is_err());
     }
 }


### PR DESCRIPTION
Without this, the following results in an error:

```rust
fn subnlas_by_kind<'a>(nlas: &'a [u8]) -> HashMap<u16, Vec<&'a [u8]>> {
	let mut out = HashMap::new();
	for n in NlasIterator::new(nlas) {
		let n = n.unwrap();
		let entry: &mut Vec<_> = out.entry(n.kind()).or_default();
		(*entry).push(n.value())
	}
	out
}
```

```
error[E0515]: cannot return value referencing local variable `n`
    |
212 |         (*entry).push(n.value())
    |                       - `n` is borrowed here
213 |     }
214 |     out
    |     ^^^ returns a value referencing data owned by the current function
```