### PR TITLE
Revert back to paste dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/rust-netlink/netlink-packet-core"
 description = "netlink packet types"
 
 [dependencies]
-pastey = "0.1.0"
+paste = "1"
 
 [dev-dependencies]
 netlink-packet-route = "0.13.0"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,9 @@
+[licenses]
+allow = [
+    "Apache-2.0",
+    "MIT",
+]
+
+[[advisories.ignore]]
+id = "RUSTSEC-2024-0436"
+reason = "Unmaintained paste is consider as finished which is better than un-vetted altertives"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,4 +295,4 @@ pub use self::traits::{
 
 // For buffer! macros
 #[doc(hidden)]
-pub use pastey::paste;
+pub use paste::paste;

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -5,7 +5,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
-use pastey::paste;
+use paste::paste;
 
 use crate::DecodeError;
 


### PR DESCRIPTION
Even the `paste` crate is unmaintained, it is still better than
unproven alternatives:
 1. Only used during building stage for macro expansion which has been
    widely tested by 10k+ crates. If there is a bug, rust compiler
    should noticed it.
 2. The alternative `pastey` is not proved by community yet.

Included `deny.toml` to make `cargo deny check` happy.