### PR TITLE
Swap paste for pastey (RUSTSEC-2024-0436)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/rust-netlink/netlink-packet-core"
 description = "netlink packet types"
 
 [dependencies]
-paste = "1"
+pastey = "0.2"
 
 [dev-dependencies]
 netlink-packet-route = "0.13.0"

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,3 @@ allow = [
     "MIT",
 ]
 
-[[advisories.ignore]]
-id = "RUSTSEC-2024-0436"
-reason = "Unmaintained paste is consider as finished which is better than un-vetted altertives"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,4 +295,4 @@ pub use self::traits::{
 
 // For buffer! macros
 #[doc(hidden)]
-pub use paste::paste;
+pub use pastey::paste;

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -5,7 +5,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
-use paste::paste;
+use pastey::paste;
 
 use crate::DecodeError;
 


### PR DESCRIPTION
Closes #41 if you'd like a low-risk stopgap.
 
`paste` is unmaintained (RUSTSEC-2024-0436). `pastey` is a maintained drop-in fork with the same paste! macro semantics — the swap is the crate name in Cargo.toml plus the two import paths; macro call sites are unchanged.

4 files, +3/-6. cargo test and doctests pass unchanged.

Also removes the corresponding `[[advisories.ignore]]` entry in deny.toml.

I understand from #41 that the preferred long-term direction is to drop buffer!() and self-parse (as you prototyped in nispor/mozim#59). But I thought it might be quicker to submit this in the mean time and clear the audit/deny warning for downstream consumers until that refactor lands. If you don't want to do this let me know if I should have a go at a PR to convert one of the buffer types as per your original plan.

Submitted manually but with assistance from Claude Code.