### PR TITLE
Add lazy ErrorContext::with_context

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,18 @@ const PAYLOAD: Rest = 4..;
 const ERROR_HEADER_LEN: usize = PAYLOAD.start;
 
 pub trait ErrorContext<T: std::fmt::Display> {
+    /// Attach context to an error.
     fn context(self, msg: T) -> Self;
+
+    /// Attach context lazily, so the message is only built when
+    /// there is actually an error to attach it to.
+    fn with_context<F>(self, f: F) -> Self
+    where
+        F: FnOnce() -> T,
+        Self: Sized,
+    {
+        self.context(f())
+    }
 }
 
 #[derive(Debug)]
@@ -33,6 +44,17 @@ where
         match self {
             Ok(t) => Ok(t),
             Err(e) => Err(e.context(msg)),
+        }
+    }
+
+    /// Only render the error on the Err case
+    fn with_context<F>(self, f: F) -> Result<T, DecodeError>
+    where
+        F: FnOnce() -> M,
+    {
+        match self {
+            Ok(t) => Ok(t),
+            Err(e) => Err(e.context(f())),
         }
     }
 }


### PR DESCRIPTION
`context()` takes its message by value, so the expression producing it is evaluated by the caller before the call is entered even when it is `Ok`. Callers that pass `format!()` pay to build a string on every success.

`with_context()` evaluates lazily only on the error paths


Naming copied from anyhow: https://docs.rs/anyhow/latest/anyhow/trait.Context.html#tymethod.with_context

See https://github.com/rust-netlink/netlink-packet-route/issues/297 for performance gain