### PR TITLE
Disable tests on big-endian targets

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -347,6 +347,8 @@ impl<T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> NetlinkBuffer<&mut T> {
     }
 }
 
+// test data are using hard coded little endian byte order, not for big-endian
+#[cfg(not(target_endian = "big"))]
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/src/done.rs
+++ b/src/done.rs
@@ -108,6 +108,8 @@ impl<T: AsRef<[u8]>> Parseable<DoneBuffer<&T>> for DoneMessage {
     }
 }
 
+// test data are using hard coded little endian byte order, not for big-endian
+#[cfg(not(target_endian = "big"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -318,6 +318,8 @@ impl From<ErrorMessage> for io::Error {
     }
 }
 
+// test data are using hard coded little endian byte order, not for big-endian
+#[cfg(not(target_endian = "big"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/header.rs
+++ b/src/header.rs
@@ -66,6 +66,8 @@ impl<T: AsRef<[u8]> + ?Sized> Parseable<NetlinkBuffer<&T>> for NetlinkHeader {
     }
 }
 
+// test data are using hard coded little endian byte order, not for big-endian
+#[cfg(not(target_endian = "big"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/message.rs
+++ b/src/message.rs
@@ -178,6 +178,8 @@ where
     }
 }
 
+// test data are using hard coded little endian byte order, not for big-endian
+#[cfg(not(target_endian = "big"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/nla.rs
+++ b/src/nla.rs
@@ -323,6 +323,8 @@ impl<'buffer, T: AsRef<[u8]> + ?Sized + 'buffer> Iterator
     }
 }
 
+// test data are using hard coded little endian byte order, not for big-endian
+#[cfg(not(target_endian = "big"))]
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
The test data are hard-coded in little-endian byte order, so the test
cases should skip on big-endian system(e.g. s390x)