### PR TITLE
New release 0.9.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,13 @@
 # Changelog
-## [Unreleased]
+## [0.9.0] - 2026-08-18
 ### Breaking changes
- - Remove the `buffer!` macro.
+ - Remove `buffer!` macros and `paste` dependency. (aa5e7ed)
 
 ### New features
- - N/A
+ - Add lazy ErrorContext::with_context. (4fc434c)
 
 ### Bug fixes
- - N/A
+ - Disable tests on big-endian targets. (818cbeb)
 
 ## [0.8.2] - 2026-08-05
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-core"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-core"


### PR DESCRIPTION
=== Breaking changes
 - Remove `buffer!` macros and `paste` dependency. (aa5e7ed)

=== New features
 - Add lazy ErrorContext::with_context. (4fc434c)

=== Bug fixes
 - Disable tests on big-endian targets. (818cbeb)